### PR TITLE
Bundle less lodash

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,5 +1,4 @@
 var _flatten = require("lodash.flatten");
-var _isArray = require("lodash.isarray");
 var _isEqual = require("lodash.isequal");
 var _isPlainObject = require("lodash.isplainobject");
 var _keys = require("lodash.keys");
@@ -66,7 +65,7 @@ function diff (from, to) {
     });
 
     return _flatten(ops, true);
-  } else if (_isArray(from) && _isArray(to)) {
+  } else if (Array.isArray(from) && Array.isArray(to)) {
     var matrix = levenshtein(from, to);
     ops = [];
 

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,4 +1,10 @@
-var _ = require("lodash");
+var _flatten = require("lodash.flatten");
+var _isArray = require("lodash.isarray");
+var _isEqual = require("lodash.isequal");
+var _isPlainObject = require("lodash.isplainobject");
+var _keys = require("lodash.keys");
+var _map = require("lodash.map");
+var _union = require("lodash.union");
 var pointer = require("json-pointer");
 var levenshtein = require("./levenshtein");
 
@@ -36,10 +42,10 @@ function matrixToOperations (matrix, i, j) {
 function diff (from, to) {
   var ops = [];
 
-  if (_.isEqual(from, to)) {
+  if (_isEqual(from, to)) {
     return [];
-  } else if (_.isPlainObject(from) && _.isPlainObject(to)) {
-    var keys = _.union(_.keys(from), _.keys(to));
+  } else if (_isPlainObject(from) && _isPlainObject(to)) {
+    var keys = _union(_keys(from), _keys(to));
 
     ops = keys.map(function (key) {
       var hasFrom = from.hasOwnProperty(key);
@@ -60,8 +66,8 @@ function diff (from, to) {
       }
     });
 
-    return _.flatten(ops, true);
-  } else if (_.isArray(from) && _.isArray(to)) {
+    return _flatten(ops, true);
+  } else if (_isArray(from) && _isArray(to)) {
     var matrix = levenshtein(from, to);
     ops = [];
 
@@ -105,7 +111,7 @@ function diff (from, to) {
 
 module.exports = function (from, to) {
   var ops = diff(from, to);
-  ops = _.map(ops, function (op) {
+  ops = _map(ops, function (op) {
     op.path = pointer.compile(op.path.map(function (p) { return "" + p; }));
 
     return op;

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -3,7 +3,6 @@ var _isArray = require("lodash.isarray");
 var _isEqual = require("lodash.isequal");
 var _isPlainObject = require("lodash.isplainobject");
 var _keys = require("lodash.keys");
-var _map = require("lodash.map");
 var _union = require("lodash.union");
 var pointer = require("json-pointer");
 var levenshtein = require("./levenshtein");
@@ -111,7 +110,7 @@ function diff (from, to) {
 
 module.exports = function (from, to) {
   var ops = diff(from, to);
-  ops = _map(ops, function (op) {
+  ops = ops.map(function (op) {
     op.path = pointer.compile(op.path.map(function (p) { return "" + p; }));
 
     return op;

--- a/lib/levenshtein.js
+++ b/lib/levenshtein.js
@@ -1,4 +1,6 @@
-var _ = require("lodash");
+var _isEqual = require("lodash.isequal");
+var _min = require("lodash.min");
+var _range = require("lodash.range");
 
 // Compute the levenshtein edit distance matrix for two lists.
 //
@@ -8,29 +10,29 @@ var _ = require("lodash");
 // Returns an m*n matrix, where the (i, j) cell contains the levenshtein
 // distance between the i-element prefix of from and the j-element prefix of to.
 module.exports = function (from, to) {
-  if (_.isEqual(from, to)) {
+  if (_isEqual(from, to)) {
     return null;
   }
 
   var m = from.length;
   var n = to.length;
-  var d = _.range(0, m + 1).map(function (x) {
+  var d = _range(0, m + 1).map(function (x) {
     return [x];
   });
 
-  d[0] = _.range(0, n + 1);
+  d[0] = _range(0, n + 1);
 
   for (var i = 1; i <= m; i++) {
     for (var j = 1; j <= n; j++) {
       var replacementCost = 1;
 
-      if (_.isEqual(from[i - 1], to[j - 1])) {
+      if (_isEqual(from[i - 1], to[j - 1])) {
         replacementCost = 0;
       }
 
-      d[i][j] = _.min([d[i - 1][j - 1] + replacementCost,
-                       d[i - 1][j] + 1,
-                       d[i][j - 1] + 1]);
+      d[i][j] = _min([d[i - 1][j - 1] + replacementCost,
+                      d[i - 1][j] + 1,
+                      d[i][j - 1] + 1]);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "lodash.isequal": "^4.1.4",
     "lodash.isplainobject": "^4.0.4",
     "lodash.keys": "^4.0.6",
-    "lodash.map": "^4.3.0",
     "lodash.min": "^4.0.0",
     "lodash.range": "^3.1.4",
     "lodash.union": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,15 @@
   "homepage": "https://github.com/CQQL/rfc6902-json-diff-js",
   "dependencies": {
     "json-pointer": "^0.2",
-    "lodash": "^3.1.0"
+    "lodash.flatten": "^4.2.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isequal": "^4.1.4",
+    "lodash.isplainobject": "^4.0.4",
+    "lodash.keys": "^4.0.6",
+    "lodash.map": "^4.3.0",
+    "lodash.min": "^4.0.0",
+    "lodash.range": "^3.1.4",
+    "lodash.union": "^4.3.0"
   },
   "devDependencies": {
     "mocha": "^2.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "json-pointer": "^0.2",
     "lodash.flatten": "^4.2.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isequal": "^4.1.4",
     "lodash.isplainobject": "^4.0.4",
     "lodash.keys": "^4.0.6",


### PR DESCRIPTION
Thanks so much for this package! I am in process of using it do document comparisons for an open-source legal contract software system I develop.

This small pull request:
1. replaces the dependency and use of lodash, the umbrella package, with dependencies and uses of the needed lodash functions as individual npm packages.
2. uses ECMAScript-standard `map` and `Array.isArray` instead of equivalent lodash implementations, to further slim things down.

None of this probably matters much for use on the server side, but it should substantially reduce front-end package size with Browserify, Webpack, and similar tools. This is mostly on account of how "large" umbrella lodash is, and how well lodash has done splitting out its API and underlying helper functions to individual npm packages.

I've done my best to mimic the existing code style, but please feel free to land with whatever changes you'd like.

Happy to acknowledge that this package is MIT-licensed, and to make everything I contribute available on the same terms.

Best,

K
